### PR TITLE
fix component names in AndroidManifest of EmergencyGestureAction

### DIFF
--- a/EmergencyGestureAction/AndroidManifest.xml
+++ b/EmergencyGestureAction/AndroidManifest.xml
@@ -33,9 +33,9 @@
         android:appComponentFactory="androidx.core.app.CoreComponentFactory"
         tools:replace="android:appComponentFactory">
 
-        <activity-alias android:name=".action.EmergencyAction"
+        <activity-alias android:name=".EmergencyAction"
                         android:label="@string/emergency_action_title"
-                        android:targetActivity=".action.EmergencyActionActivity"
+                        android:targetActivity=".EmergencyActionActivity"
                         android:permission="android.permission.MANAGE_SENSOR_PRIVACY"
                         android:directBootAware="true"
                         android:enabled="true"
@@ -48,7 +48,7 @@
         </activity-alias>
 
         <activity
-            android:name=".action.EmergencyActionActivity"
+            android:name=".EmergencyActionActivity"
             android:label="@string/emergency_action_title"
             android:theme="@style/AppThemeEmergencyAction"
             android:directBootAware="true"
@@ -59,7 +59,7 @@
             android:exported="false"/>
 
         <service
-            android:name=".action.service.EmergencyActionForegroundService"
+            android:name=".service.EmergencyActionForegroundService"
             android:directBootAware="true"
             android:foregroundServiceType="specialUse"
             android:exported="false">
@@ -67,7 +67,7 @@
         </service>
 
         <receiver
-            android:name=".action.broadcast.EmergencyActionBroadcastReceiver"
+            android:name=".broadcast.EmergencyActionBroadcastReceiver"
             android:exported="false">
             <intent-filter>
                 <action android:name="com.android.emergency.broadcast.MAKE_EMERGENCY_CALL" />


### PR DESCRIPTION
f09cd1ce7da9e7442aa7d91043f34609a09e7e57 changed package name from com.android.emergency to com.android.emergency.action , but relative components were not updated.

This bug broke the "press power button 5 times for emergency call" gesture.

Stock Pixel OS is not affected since it uses the non-AOSP SafetyHub app for this gesture.

Part of a changelist:
https://github.com/GrapheneOS/platform_manifest/pull/37
https://github.com/GrapheneOS/script/pull/53